### PR TITLE
[Schema] separate member table

### DIFF
--- a/prisma/migrations/20221008125929_member_seperate/migration.sql
+++ b/prisma/migrations/20221008125929_member_seperate/migration.sql
@@ -1,0 +1,41 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `account_id` on the `member` table. All the data in the column will be lost.
+  - You are about to drop the column `password` on the `member` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[student_id]` on the table `member` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "member_account_id_key";
+
+-- DropIndex
+DROP INDEX "member_email_key";
+
+-- AlterTable
+ALTER TABLE "member" DROP COLUMN "account_id",
+DROP COLUMN "password",
+ADD COLUMN     "address" TEXT,
+ADD COLUMN     "phone" TEXT,
+ALTER COLUMN "email" DROP NOT NULL;
+
+-- CreateTable
+CREATE TABLE "member_account" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "member_id" TEXT NOT NULL,
+    "nickname" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+
+    CONSTRAINT "member_account_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "member_account_member_id_key" ON "member_account"("member_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "member_student_id_key" ON "member"("student_id");
+
+-- AddForeignKey
+ALTER TABLE "member_account" ADD CONSTRAINT "member_account_member_id_fkey" FOREIGN KEY ("member_id") REFERENCES "member"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20221008154445_member_separate/migration.sql
+++ b/prisma/migrations/20221008154445_member_separate/migration.sql
@@ -3,9 +3,13 @@
 
   - You are about to drop the column `account_id` on the `member` table. All the data in the column will be lost.
   - You are about to drop the column `password` on the `member` table. All the data in the column will be lost.
+  - The `type` column on the `member` table would be dropped and recreated. This will lead to data loss if there is data in the column.
   - A unique constraint covering the columns `[student_id]` on the table `member` will be added. If there are existing duplicate values, this will fail.
 
 */
+-- CreateEnum
+CREATE TYPE "member_type" AS ENUM ('NOVICE', 'ASSOCIATE', 'REGULAR', 'HONORARY', 'EXECUTIVE', 'PRESIDENT', 'KUAAATELECOM');
+
 -- DropIndex
 DROP INDEX "member_account_id_key";
 
@@ -17,7 +21,12 @@ ALTER TABLE "member" DROP COLUMN "account_id",
 DROP COLUMN "password",
 ADD COLUMN     "address" TEXT,
 ADD COLUMN     "phone" TEXT,
+DROP COLUMN "type",
+ADD COLUMN     "type" "member_type" NOT NULL DEFAULT 'NOVICE',
 ALTER COLUMN "email" DROP NOT NULL;
+
+-- DropEnum
+DROP TYPE "user_type";
 
 -- CreateTable
 CREATE TABLE "member_account" (

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,19 +12,19 @@ datasource db {
 }
 
 model Member {
-  id           String   @id @default(uuid())
-  createdAt    DateTime @default(now()) @map("created_at")
-  updatedAt    DateTime @updatedAt @map("updated_at")
-  studentId    String   @unique @map("student_id")
+  id           String     @id @default(uuid())
+  createdAt    DateTime   @default(now()) @map("created_at")
+  updatedAt    DateTime   @updatedAt @map("updated_at")
+  studentId    String     @unique @map("student_id")
   name         String
-  type         UserType @default(NOVICE)
+  type         MemberType @default(NOVICE)
   email        String?
   address      String?
   phone        String?
   generation   Int
-  majorId      Int      @map("major_id")
-  registeredAt DateTime @map("registered_at") @db.Date
-  isActive     Boolean  @default(true) @map("is_active")
+  majorId      Int        @map("major_id")
+  registeredAt DateTime   @map("registered_at") @db.Date
+  isActive     Boolean    @default(true) @map("is_active")
 
   major         Major          @relation(fields: [majorId], references: [id])
   serve         Serve[]
@@ -160,7 +160,7 @@ model Rental {
   @@map("rental")
 }
 
-enum UserType {
+enum MemberType {
   NOVICE // 준회원
   ASSOCIATE // 부회원
   REGULAR // 정회원
@@ -169,7 +169,7 @@ enum UserType {
   PRESIDENT // 회장
   KUAAATELECOM // 쿠아텔레콤
 
-  @@map("user_type")
+  @@map("member_type")
 }
 
 enum EventType {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,8 +6,8 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider          = "postgresql"
+  url               = env("DATABASE_URL")
   shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
@@ -15,23 +15,37 @@ model Member {
   id           String   @id @default(uuid())
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")
-  accountId    String   @unique @map("account_id")
-  password     String
-  type         UserType @default(NOVICE)
+  studentId    String   @unique @map("student_id")
   name         String
-  email        String   @unique
+  type         UserType @default(NOVICE)
+  email        String?
+  address      String?
+  phone        String?
   generation   Int
-  studentId    String   @map("student_id")
   majorId      Int      @map("major_id")
   registeredAt DateTime @map("registered_at") @db.Date
   isActive     Boolean  @default(true) @map("is_active")
 
-  major      Major        @relation(fields: [majorId], references: [id])
-  serve      Serve[]
-  Attendance Attendance[]
-  Ticket     Ticket[]
+  major         Major          @relation(fields: [majorId], references: [id])
+  serve         Serve[]
+  attendance    Attendance[]
+  ticket        Ticket[]
+  memberAccount MemberAccount?
 
   @@map("member")
+}
+
+model MemberAccount {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+  memberId  String   @unique @map("member_id")
+  nickname  String
+  password  String
+
+  member Member @relation(fields: [memberId], references: [id])
+
+  @@map("member_account")
 }
 
 model Major {
@@ -71,7 +85,7 @@ model Event {
   type        EventType
   startTime   DateTime     @map("start_time")
   endTime     DateTime?    @map("end_time")
-  Attendance  Attendance[]
+  attendance  Attendance[]
 
   @@map("event")
 }
@@ -100,7 +114,7 @@ model Equipment {
   description String?
 
   casing Casing   @relation(fields: [casingId], references: [id])
-  Rental Rental[]
+  rental Rental[]
 
   @@map("equipment")
 }
@@ -112,7 +126,7 @@ model Casing {
   name      String
   place     String
 
-  Equipment Equipment[]
+  equipment Equipment[]
 
   @@map("casing")
 }
@@ -127,7 +141,7 @@ model Ticket {
   purpose   String
 
   member Member   @relation(fields: [memberId], references: [id])
-  Rental Rental[]
+  rental Rental[]
 
   @@map("ticket")
 }


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [X] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc


## Purpose
- 멤버 테이블에서 auth와 관련된 부분만 떼서 member_account라는 테이블을 생성했습니다.


## Why
- 기존 member 테이블은 본인의 가입 없이 임원들의 입력으로 추가될 정보들을 포함합니다.
- nickname, password는 가입 시에 추가될 예정이므로 account에 포함했습니다.
- account의 fk를 studentID(현 시점에서 우리가 ID로 하기로 한)로 잡을지, 그냥 member pk로 잡을지 고민했는데, 일관성 있게 member pk로 잡는쪽으로 했습니다. 


## Related issue
- resolve #8 

## Checklist
- 리뷰 완료되는 대로 dev DB에 migration할 예정입니다.
