### PR TITLE
[Feat] Read & Update Own Member Info

### DIFF
--- a/src/auth/common/decorator/member.decorator.ts
+++ b/src/auth/common/decorator/member.decorator.ts
@@ -1,7 +1,7 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { Account } from '../../account/account.entity';
 
-export const CurrentMember = createParamDecorator(
+export const CurrentAccount = createParamDecorator(
   (data: unknown, ctx: ExecutionContext): Account => {
     const request = ctx.switchToHttp().getRequest();
     return request.user;

--- a/src/member/common/dto/member-info.dto.ts
+++ b/src/member/common/dto/member-info.dto.ts
@@ -32,6 +32,9 @@ export class MemberInfoDto {
   @ApiProperty({ type: String, nullable: true })
   address!: string | null;
 
+  @ApiProperty({ type: String, nullable: true })
+  nickname!: string | null;
+
   @ApiProperty({ type: MajorInfoDto })
   major!: MajorInfoDto;
 
@@ -45,6 +48,7 @@ export class MemberInfoDto {
       email: member.email,
       phone: member.phone,
       address: member.address,
+      nickname: member.nickname,
       major: {
         name: major.name,
         college: major.college,

--- a/src/member/common/dto/member-info.dto.ts
+++ b/src/member/common/dto/member-info.dto.ts
@@ -1,4 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Member } from '../../member/member.entity';
+import { Major } from '../../member/major.entity';
 
 class MajorInfoDto {
   @ApiProperty({ type: String })
@@ -16,7 +18,7 @@ export class MemberInfoDto {
   studentId!: string;
 
   @ApiProperty({ type: String })
-  registeredAt!: Date;
+  registeredAt!: string;
 
   @ApiProperty({ type: Number })
   generation!: number;
@@ -32,4 +34,21 @@ export class MemberInfoDto {
 
   @ApiProperty({ type: MajorInfoDto })
   major!: MajorInfoDto;
+
+  static async of(member: Member): Promise<MemberInfoDto> {
+    const major: Major = await member.getMajor();
+    return {
+      name: member.name,
+      studentId: member.studentId,
+      registeredAt: member.registeredAt.toISOString().split('T')[0],
+      generation: member.generation,
+      email: member.email,
+      phone: member.phone,
+      address: member.address,
+      major: {
+        name: major.name,
+        college: major.college,
+      },
+    };
+  }
 }

--- a/src/member/common/dto/member-info.dto.ts
+++ b/src/member/common/dto/member-info.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class MajorInfoDto {
+  @ApiProperty({ type: String })
+  name!: string;
+
+  @ApiProperty({ type: String })
+  college!: string;
+}
+
+export class MemberInfoDto {
+  @ApiProperty({ type: String })
+  name!: string;
+
+  @ApiProperty({ type: String })
+  studentId!: string;
+
+  @ApiProperty({ type: String })
+  registeredAt!: Date;
+
+  @ApiProperty({ type: Number })
+  generation!: number;
+
+  @ApiProperty({ type: String, nullable: true })
+  email!: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  phone!: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  address!: string | null;
+
+  @ApiProperty({ type: MajorInfoDto })
+  major!: MajorInfoDto;
+}

--- a/src/member/common/payload/create-members.payload.ts
+++ b/src/member/common/payload/create-members.payload.ts
@@ -4,12 +4,11 @@ import {
   IsDefined,
   IsInt,
   IsNotEmpty,
-  IsOptional,
   IsString,
   MinLength,
   ValidateNested,
 } from 'class-validator';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 
 export class CreateMemberPayload {
@@ -34,28 +33,6 @@ export class CreateMemberPayload {
   @Transform(({ value }) => new Date(value))
   @ApiProperty({ description: '가입일자', type: String, example: '2021-01-01' })
   registeredAt!: Date;
-
-  @IsOptional()
-  @MinLength(1)
-  @IsString()
-  @ApiPropertyOptional({ description: '이메일', nullable: true, type: String })
-  email?: string | null;
-
-  @IsOptional()
-  @MinLength(1)
-  @IsString()
-  @ApiPropertyOptional({
-    description: '전화번호',
-    nullable: true,
-    type: String,
-  })
-  phone?: string | null;
-
-  @IsOptional()
-  @MinLength(1)
-  @IsString()
-  @ApiPropertyOptional({ description: '주소', nullable: true, type: String })
-  address?: string | null;
 }
 
 export class CreateMembersPayload {

--- a/src/member/common/payload/update-member-by-admin.payload.ts
+++ b/src/member/common/payload/update-member-by-admin.payload.ts
@@ -2,7 +2,6 @@ import {
   IsDate,
   IsEnum,
   IsInt,
-  IsOptional,
   IsString,
   Length,
   MinLength,
@@ -42,26 +41,4 @@ export class UpdateMemberByAdminPayload {
     enum: MemberType,
   })
   type?: MemberType;
-
-  @IsOptional()
-  @MinLength(1)
-  @IsString()
-  @ApiPropertyOptional({ description: '이메일', nullable: true, type: String })
-  email?: string | null;
-
-  @IsOptional()
-  @MinLength(1)
-  @IsString()
-  @ApiPropertyOptional({
-    description: '전화번호',
-    nullable: true,
-    type: String,
-  })
-  phone?: string | null;
-
-  @IsOptional()
-  @MinLength(1)
-  @IsString()
-  @ApiPropertyOptional({ description: '주소', nullable: true, type: String })
-  address?: string | null;
 }

--- a/src/member/common/payload/update-member-by-admin.payload.ts
+++ b/src/member/common/payload/update-member-by-admin.payload.ts
@@ -1,0 +1,67 @@
+import {
+  IsDate,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Length,
+  MinLength,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { MemberType } from '@prisma/client';
+
+export class UpdateMemberByAdminPayload {
+  @MinLength(1)
+  @IsString()
+  @ApiPropertyOptional({ description: '이름', type: String })
+  name?: string;
+
+  @Length(10, 10)
+  @IsString()
+  @ApiPropertyOptional({ description: '학번', type: String })
+  studentId?: string;
+
+  @IsInt()
+  @ApiPropertyOptional({ description: '전공ID', type: Number })
+  majorId?: number;
+
+  @IsDate()
+  @Transform(({ value }) => new Date(value))
+  @ApiPropertyOptional({
+    description: '가입일자',
+    type: String,
+    example: '2021-01-01',
+  })
+  registeredAt?: Date;
+
+  @IsEnum(MemberType)
+  @ApiPropertyOptional({
+    description: '회원권한',
+    type: String,
+    enum: MemberType,
+  })
+  type?: MemberType;
+
+  @IsOptional()
+  @MinLength(1)
+  @IsString()
+  @ApiPropertyOptional({ description: '이메일', nullable: true, type: String })
+  email?: string | null;
+
+  @IsOptional()
+  @MinLength(1)
+  @IsString()
+  @ApiPropertyOptional({
+    description: '전화번호',
+    nullable: true,
+    type: String,
+  })
+  phone?: string | null;
+
+  @IsOptional()
+  @MinLength(1)
+  @IsString()
+  @ApiPropertyOptional({ description: '주소', nullable: true, type: String })
+  address?: string | null;
+}

--- a/src/member/common/payload/update-member.payload.ts
+++ b/src/member/common/payload/update-member.payload.ts
@@ -1,5 +1,6 @@
 import {
   IsDate,
+  IsEnum,
   IsInt,
   IsOptional,
   IsString,
@@ -8,6 +9,7 @@ import {
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
+import { MemberType } from '@prisma/client';
 
 export class UpdateMemberPayload {
   @MinLength(1)
@@ -32,6 +34,14 @@ export class UpdateMemberPayload {
     example: '2021-01-01',
   })
   registeredAt?: Date;
+
+  @IsEnum(MemberType)
+  @ApiPropertyOptional({
+    description: '회원권한',
+    type: String,
+    enum: MemberType,
+  })
+  type?: MemberType;
 
   @IsOptional()
   @MinLength(1)

--- a/src/member/common/payload/update-member.payload.ts
+++ b/src/member/common/payload/update-member.payload.ts
@@ -1,47 +1,11 @@
-import {
-  IsDate,
-  IsEnum,
-  IsInt,
-  IsOptional,
-  IsString,
-  Length,
-  MinLength,
-} from 'class-validator';
+import { IsOptional, IsString, MinLength } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform } from 'class-transformer';
-import { MemberType } from '@prisma/client';
 
 export class UpdateMemberPayload {
   @MinLength(1)
   @IsString()
-  @ApiPropertyOptional({ description: '이름', type: String })
-  name?: string;
-
-  @Length(10, 10)
-  @IsString()
-  @ApiPropertyOptional({ description: '학번', type: String })
-  studentId?: string;
-
-  @IsInt()
-  @ApiPropertyOptional({ description: '전공ID', type: Number })
-  majorId?: number;
-
-  @IsDate()
-  @Transform(({ value }) => new Date(value))
-  @ApiPropertyOptional({
-    description: '가입일자',
-    type: String,
-    example: '2021-01-01',
-  })
-  registeredAt?: Date;
-
-  @IsEnum(MemberType)
-  @ApiPropertyOptional({
-    description: '회원권한',
-    type: String,
-    enum: MemberType,
-  })
-  type?: MemberType;
+  @ApiPropertyOptional({ description: '닉네임', type: String })
+  nickname?: string;
 
   @IsOptional()
   @MinLength(1)

--- a/src/member/member.admin.controller.ts
+++ b/src/member/member.admin.controller.ts
@@ -19,7 +19,7 @@ import {
 } from '@nestjs/swagger';
 import { CreateResultDto } from './common/dto/create-result.dto';
 import { CreateMembersPayload } from './common/payload/create-members.payload';
-import { UpdateMemberPayload } from './common/payload/update-member.payload';
+import { UpdateMemberByAdminPayload } from './common/payload/update-member-by-admin.payload';
 import { JwtAuthGuard } from '../auth/common/guard/jwt-auth.guard';
 import { RoleGuard } from '../auth/common/guard/role.gard';
 import { MemberType } from '@prisma/client';
@@ -50,7 +50,7 @@ export class MemberAdminController {
   @ApiNoContentResponse()
   async updateMember(
     @Param('memberId', ParseUUIDPipe) id: string,
-    @Body() payload: UpdateMemberPayload,
+    @Body() payload: UpdateMemberByAdminPayload,
   ): Promise<void> {
     await this.memberService.updateMember(id, payload);
   }

--- a/src/member/member.admin.service.ts
+++ b/src/member/member.admin.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { CreateMembersPayload } from './common/payload/create-members.payload';
 import { CreateResultDto } from './common/dto/create-result.dto';
-import { UpdateMemberPayload } from './common/payload/update-member.payload';
+import { UpdateMemberByAdminPayload } from './common/payload/update-member-by-admin.payload';
 import { MemberFactory } from './member/member.factory';
 import { Member } from './member/member.entity';
+import { UpdateMemberData } from './member/type/update-member-data.type';
 
 @Injectable()
 export class MemberAdminService {
@@ -14,9 +15,23 @@ export class MemberAdminService {
     return { memberIds: members.map((member) => member.id) };
   }
 
-  async updateMember(id: string, payload: UpdateMemberPayload): Promise<void> {
+  async updateMember(
+    id: string,
+    payload: UpdateMemberByAdminPayload,
+  ): Promise<void> {
     const member = await this.memberFactory.getMemberById(id);
-    await member.updateMember(payload);
+
+    const updateData: UpdateMemberData = {
+      name: payload.name,
+      type: payload.type,
+      studentId: payload.studentId,
+      registeredAt: payload.registeredAt,
+      majorId: payload.majorId,
+      email: payload.email,
+      phone: payload.phone,
+      address: payload.address,
+    };
+    await member.updateMember(updateData);
   }
 
   async deleteMember(id: string): Promise<void> {

--- a/src/member/member.admin.service.ts
+++ b/src/member/member.admin.service.ts
@@ -27,9 +27,6 @@ export class MemberAdminService {
       studentId: payload.studentId,
       registeredAt: payload.registeredAt,
       majorId: payload.majorId,
-      email: payload.email,
-      phone: payload.phone,
-      address: payload.address,
     };
     await member.updateMember(updateData);
   }

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -1,9 +1,27 @@
-import { Controller } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { MemberService } from './member.service';
+import { JwtAuthGuard } from '../auth/common/guard/jwt-auth.guard';
+import { CurrentAccount } from '../auth/common/decorator/member.decorator';
+import { Account } from '../auth/account/account.entity';
+import { MemberInfoDto } from './common/dto/member-info.dto';
 
 @ApiTags('Member API')
 @Controller('api/members')
 export class MemberController {
   constructor(private readonly memberService: MemberService) {}
+
+  @Get('member')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '본인의 회원정보를 확인합니다.' })
+  @ApiOkResponse({ type: MemberInfoDto })
+  async getMember(@CurrentAccount() account: Account): Promise<MemberInfoDto> {
+    return this.memberService.getMember(account);
+  }
 }

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Patch, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiNoContentResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -10,6 +11,7 @@ import { JwtAuthGuard } from '../auth/common/guard/jwt-auth.guard';
 import { CurrentAccount } from '../auth/common/decorator/member.decorator';
 import { Account } from '../auth/account/account.entity';
 import { MemberInfoDto } from './common/dto/member-info.dto';
+import { UpdateMemberPayload } from './common/payload/update-member.payload';
 
 @ApiTags('Member API')
 @Controller('api/members')
@@ -23,5 +25,17 @@ export class MemberController {
   @ApiOkResponse({ type: MemberInfoDto })
   async getMember(@CurrentAccount() account: Account): Promise<MemberInfoDto> {
     return this.memberService.getMember(account);
+  }
+
+  @Patch('member')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '본인의 회원정보를 수정합니다.' })
+  @ApiNoContentResponse()
+  async updateMember(
+    @CurrentAccount() account: Account,
+    @Body() payload: UpdateMemberPayload,
+  ): Promise<void> {
+    return this.memberService.updateMember(account, payload);
   }
 }

--- a/src/member/member.module.ts
+++ b/src/member/member.module.ts
@@ -3,6 +3,8 @@ import { MemberAdminService } from './member.admin.service';
 import { MemberAdminController } from './member.admin.controller';
 import { MemberFactory } from './member/member.factory';
 import { MemberRepository } from './member/member.repository';
+import { MemberService } from './member.service';
+import { MemberController } from './member.controller';
 
 const memberRepository: ClassProvider = {
   provide: 'IMemberRepository',
@@ -10,7 +12,12 @@ const memberRepository: ClassProvider = {
 };
 
 @Module({
-  providers: [MemberAdminService, MemberFactory, memberRepository],
-  controllers: [MemberAdminController],
+  providers: [
+    MemberAdminService,
+    MemberFactory,
+    memberRepository,
+    MemberService,
+  ],
+  controllers: [MemberAdminController, MemberController],
 })
 export class MemberModule {}

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -2,13 +2,17 @@ import { Injectable } from '@nestjs/common';
 import { MemberFactory } from './member/member.factory';
 import { Account } from '../auth/account/account.entity';
 import { MemberInfoDto } from './common/dto/member-info.dto';
+import { Member } from './member/member.entity';
 
 @Injectable()
 export class MemberService {
   constructor(private readonly memberFactory: MemberFactory) {}
 
   async getMember(account: Account): Promise<MemberInfoDto> {
-    const member = await this.memberFactory.getMemberById(account.memberId);
-    return {} as any;
+    const member: Member = await this.memberFactory.getMemberById(
+      account.memberId,
+    );
+
+    return MemberInfoDto.of(member);
   }
 }

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -1,7 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { MemberFactory } from './member/member.factory';
+import { Account } from '../auth/account/account.entity';
+import { MemberInfoDto } from './common/dto/member-info.dto';
 
 @Injectable()
 export class MemberService {
   constructor(private readonly memberFactory: MemberFactory) {}
+
+  async getMember(account: Account): Promise<MemberInfoDto> {
+    const member = await this.memberFactory.getMemberById(account.memberId);
+    return {} as any;
+  }
 }

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -3,6 +3,8 @@ import { MemberFactory } from './member/member.factory';
 import { Account } from '../auth/account/account.entity';
 import { MemberInfoDto } from './common/dto/member-info.dto';
 import { Member } from './member/member.entity';
+import { UpdateMemberPayload } from './common/payload/update-member.payload';
+import { UpdateMemberData } from './member/type/update-member-data.type';
 
 @Injectable()
 export class MemberService {
@@ -14,5 +16,23 @@ export class MemberService {
     );
 
     return MemberInfoDto.of(member);
+  }
+
+  async updateMember(
+    account: Account,
+    payload: UpdateMemberPayload,
+  ): Promise<void> {
+    const member: Member = await this.memberFactory.getMemberById(
+      account.memberId,
+    );
+
+    const updateData: UpdateMemberData = {
+      email: payload.email,
+      phone: payload.phone,
+      address: payload.address,
+      nickname: payload.nickname,
+    };
+
+    await member.updateMember(updateData);
   }
 }

--- a/src/member/member/interface/member.repository.interface.ts
+++ b/src/member/member/interface/member.repository.interface.ts
@@ -1,14 +1,14 @@
-import { UpdateMemberPayload } from '../../common/payload/update-member.payload';
 import { CreateMemberPayload } from '../../common/payload/create-members.payload';
 import { MemberData } from '../type/member-data.type';
 import { MemberDataWithMajor } from '../type/member-data-with-major.type';
 import { MajorData } from '../type/major-data.type';
+import { UpdateMemberData } from '../type/update-member-data.type';
 
 export interface IMemberRepository {
   getMemberById(id: string): Promise<MemberDataWithMajor | null>;
   getMemberByStudentId(studentId: string): Promise<MemberData | null>;
   createMembers(data: CreateMemberPayload[]): Promise<MemberData[]>;
-  updateMember(id: string, data: UpdateMemberPayload): Promise<MemberData>;
+  updateMember(id: string, data: UpdateMemberData): Promise<MemberData>;
   deleteMember(id: string): Promise<void>;
   getExistingMemberStudentIds(studentIds: string[]): Promise<string[]>;
   getMajor(majorId: number): Promise<MajorData | null>;

--- a/src/member/member/interface/member.repository.interface.ts
+++ b/src/member/member/interface/member.repository.interface.ts
@@ -1,18 +1,16 @@
-import { MemberDomainData } from '../type/member-domain-data.type';
-import { Major } from '@prisma/client';
 import { UpdateMemberPayload } from '../../common/payload/update-member.payload';
 import { CreateMemberPayload } from '../../common/payload/create-members.payload';
+import { MemberData } from '../type/member-data.type';
+import { MemberDataWithMajor } from '../type/member-data-with-major.type';
+import { MajorData } from '../type/major-data.type';
 
 export interface IMemberRepository {
-  getMemberById(id: string): Promise<MemberDomainData | null>;
-  getMemberByStudentId(studentId: string): Promise<MemberDomainData | null>;
-  createMembers(data: CreateMemberPayload[]): Promise<MemberDomainData[]>;
-  updateMember(
-    id: string,
-    data: UpdateMemberPayload,
-  ): Promise<MemberDomainData>;
+  getMemberById(id: string): Promise<MemberDataWithMajor | null>;
+  getMemberByStudentId(studentId: string): Promise<MemberData | null>;
+  createMembers(data: CreateMemberPayload[]): Promise<MemberData[]>;
+  updateMember(id: string, data: UpdateMemberPayload): Promise<MemberData>;
   deleteMember(id: string): Promise<void>;
   getExistingMemberStudentIds(studentIds: string[]): Promise<string[]>;
-  getMajor(majorId: number): Promise<Major | null>;
+  getMajor(majorId: number): Promise<MajorData | null>;
   isAccountExist(id: string): Promise<boolean>;
 }

--- a/src/member/member/major.entity.ts
+++ b/src/member/member/major.entity.ts
@@ -1,0 +1,13 @@
+import { MajorInput } from './type/major-input.type';
+
+export class Major {
+  id!: number;
+  name!: string;
+  college!: string;
+
+  constructor(data: MajorInput) {
+    this.id = data.id;
+    this.name = data.name;
+    this.college = data.college;
+  }
+}

--- a/src/member/member/member.entity.ts
+++ b/src/member/member/member.entity.ts
@@ -1,8 +1,12 @@
-import { MemberType, Major } from '@prisma/client';
-import { MemberDomainData } from './type/member-domain-data.type';
+import { MemberType } from '@prisma/client';
+import { MemberInput } from './type/member-input.type';
+import { MajorInput } from './type/major-input.type';
 import { IMemberRepository } from './interface/member.repository.interface';
 import { UpdateMemberPayload } from '../common/payload/update-member.payload';
 import { ConflictException } from '@nestjs/common';
+import { Major } from './major.entity';
+import { MemberData } from './type/member-data.type';
+import { MajorData } from './type/major-data.type';
 
 export class Member {
   id!: string;
@@ -10,26 +14,32 @@ export class Member {
   type!: MemberType;
   studentId!: string;
   generation!: number;
-  majorId!: number;
   registeredAt!: Date;
   email!: string | null;
   phone!: string | null;
   address!: string | null;
+  majorId!: number;
+  private major?: Major;
 
   constructor(
     private readonly memberRepository: IMemberRepository,
-    data: MemberDomainData,
+    data: MemberInput,
   ) {
     this.id = data.id;
     this.name = data.name;
     this.type = data.type;
     this.studentId = data.studentId;
     this.generation = data.generation;
-    this.majorId = data.majorId;
     this.registeredAt = data.registeredAt;
     this.email = data.email;
     this.phone = data.phone;
     this.address = data.address;
+    this.majorId = data.major.id;
+
+    // major에 MajorData를 담으면 key가 1개보다는 많음 => eager loading
+    if (Object.keys(data.major).length > 1) {
+      this.major = new Major(data.major as MajorInput);
+    }
   }
 
   // 나중에 다른 엔드포인트로 접근하는 경우 UpdateMemberPayload를 그대로 쓰는게 아니라 새로운 type을 만들어야 할듯.
@@ -43,11 +53,26 @@ export class Member {
     }
 
     // db에 반영
-    const updatedData: MemberDomainData =
-      await this.memberRepository.updateMember(this.id, data);
+    const updatedData: MemberData = await this.memberRepository.updateMember(
+      this.id,
+      data,
+    );
+
+    const memberInput: MemberInput = {
+      id: updatedData.id,
+      name: updatedData.name,
+      type: updatedData.type,
+      studentId: updatedData.studentId,
+      generation: updatedData.generation,
+      registeredAt: updatedData.registeredAt,
+      email: updatedData.email,
+      phone: updatedData.phone,
+      address: updatedData.address,
+      major: { id: updatedData.majorId },
+    };
 
     // 업데이트한 데이터로 domain을 새로 만들어서 반환
-    return new Member(this.memberRepository, updatedData);
+    return new Member(this.memberRepository, memberInput);
   }
 
   // 다른 테이블에 데이터 쌓이면?
@@ -57,8 +82,25 @@ export class Member {
     await this.memberRepository.deleteMember(this.id);
   }
 
+  async getMajor(): Promise<Major> {
+    if (!this.major) {
+      const majorData: MajorData | null = await this.memberRepository.getMajor(
+        this.majorId,
+      );
+
+      const majorInput: MajorInput = {
+        id: majorData!.id,
+        name: majorData!.name,
+        college: majorData!.college,
+      };
+
+      this.major = new Major(majorInput);
+    }
+    return this.major;
+  }
+
   private async validateStudentId(studentId: string): Promise<void> {
-    const member: MemberDomainData | null =
+    const member: MemberData | null =
       await this.memberRepository.getMemberByStudentId(studentId);
 
     if (member?.id !== this.id)
@@ -66,7 +108,9 @@ export class Member {
   }
 
   private async validateMajor(majorId: number): Promise<void> {
-    const major: Major | null = await this.memberRepository.getMajor(majorId);
+    const major: MajorData | null = await this.memberRepository.getMajor(
+      majorId,
+    );
     if (!major) throw new ConflictException('존재하지 않는 전공입니다.');
   }
 }

--- a/src/member/member/member.entity.ts
+++ b/src/member/member/member.entity.ts
@@ -18,6 +18,7 @@ export class Member {
   email!: string | null;
   phone!: string | null;
   address!: string | null;
+  nickname!: string | null;
   majorId!: number;
   private major?: Major;
 
@@ -35,6 +36,7 @@ export class Member {
     this.phone = data.phone;
     this.address = data.address;
     this.majorId = data.major.id;
+    this.nickname = data.nickname;
 
     // major에 MajorData를 담으면 key가 1개보다는 많음 => eager loading
     if (Object.keys(data.major).length > 1) {
@@ -68,6 +70,7 @@ export class Member {
       email: updatedData.email,
       phone: updatedData.phone,
       address: updatedData.address,
+      nickname: updatedData.memberAccount?.nickname ?? null,
       major: { id: updatedData.majorId },
     };
 

--- a/src/member/member/member.entity.ts
+++ b/src/member/member/member.entity.ts
@@ -2,11 +2,11 @@ import { MemberType } from '@prisma/client';
 import { MemberInput } from './type/member-input.type';
 import { MajorInput } from './type/major-input.type';
 import { IMemberRepository } from './interface/member.repository.interface';
-import { UpdateMemberPayload } from '../common/payload/update-member.payload';
 import { ConflictException } from '@nestjs/common';
 import { Major } from './major.entity';
 import { MemberData } from './type/member-data.type';
 import { MajorData } from './type/major-data.type';
+import { UpdateMemberData } from './type/update-member-data.type';
 
 export class Member {
   id!: string;
@@ -45,7 +45,7 @@ export class Member {
   }
 
   // 나중에 다른 엔드포인트로 접근하는 경우 UpdateMemberPayload를 그대로 쓰는게 아니라 새로운 type을 만들어야 할듯.
-  async updateMember(data: UpdateMemberPayload): Promise<Member> {
+  async updateMember(data: UpdateMemberData): Promise<Member> {
     if (data.studentId) {
       await this.validateStudentId(data.studentId);
     }

--- a/src/member/member/member.factory.ts
+++ b/src/member/member/member.factory.ts
@@ -38,6 +38,7 @@ export class MemberFactory {
       email: memberData.email,
       phone: memberData.phone,
       address: memberData.address,
+      nickname: memberData.memberAccount?.nickname ?? null,
       major: {
         id: memberData.major.id,
         name: memberData.major.name,
@@ -84,6 +85,7 @@ export class MemberFactory {
         email: memberData.email,
         phone: memberData.phone,
         address: memberData.address,
+        nickname: memberData.memberAccount?.nickname ?? null,
         major: {
           id: memberData.majorId,
         },

--- a/src/member/member/member.repository.ts
+++ b/src/member/member/member.repository.ts
@@ -7,6 +7,7 @@ import { MemberData } from './type/member-data.type';
 import { MemberDataWithMajor } from './type/member-data-with-major.type';
 import { MajorData } from './type/major-data.type';
 import { UpdateMemberData } from './type/update-member-data.type';
+import { CreateMemberData } from './type/create-member-data.type';
 
 const MEMBER_DATA_SELECT = {
   id: true,
@@ -73,9 +74,6 @@ export class MemberRepository implements IMemberRepository {
       generation: Number(member.studentId.slice(2, 4)),
       majorId: member.majorId,
       registeredAt: member.registeredAt,
-      email: member.email ?? null,
-      phone: member.phone ?? null,
-      address: member.address ?? null,
     }));
 
     // 한 transaction으로 처리

--- a/src/member/member/member.repository.ts
+++ b/src/member/member/member.repository.ts
@@ -106,6 +106,7 @@ export class MemberRepository implements IMemberRepository {
           ? Number(data.studentId.slice(2, 4))
           : undefined,
         majorId: data.majorId,
+        type: data.type,
         registeredAt: data.registeredAt,
         email: data.email,
         phone: data.phone,

--- a/src/member/member/member.repository.ts
+++ b/src/member/member/member.repository.ts
@@ -2,11 +2,11 @@ import { IMemberRepository } from './interface/member.repository.interface';
 import { PrismaService } from '../../common/services/prisma.service';
 import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
-import { UpdateMemberPayload } from '../common/payload/update-member.payload';
 import { CreateMemberPayload } from '../common/payload/create-members.payload';
 import { MemberData } from './type/member-data.type';
 import { MemberDataWithMajor } from './type/member-data-with-major.type';
 import { MajorData } from './type/major-data.type';
+import { UpdateMemberData } from './type/update-member-data.type';
 
 const MEMBER_DATA_SELECT = {
   id: true,
@@ -93,10 +93,7 @@ export class MemberRepository implements IMemberRepository {
     });
   }
 
-  async updateMember(
-    id: string,
-    data: UpdateMemberPayload,
-  ): Promise<MemberData> {
+  async updateMember(id: string, data: UpdateMemberData): Promise<MemberData> {
     return this.prisma.member.update({
       where: { id },
       data: {
@@ -111,6 +108,11 @@ export class MemberRepository implements IMemberRepository {
         email: data.email,
         phone: data.phone,
         address: data.address,
+        memberAccount: {
+          update: {
+            nickname: data.nickname,
+          },
+        },
       },
       select: MEMBER_DATA_SELECT,
     });

--- a/src/member/member/member.repository.ts
+++ b/src/member/member/member.repository.ts
@@ -19,6 +19,11 @@ const MEMBER_DATA_SELECT = {
   email: true,
   phone: true,
   address: true,
+  memberAccount: {
+    select: {
+      nickname: true,
+    },
+  },
 };
 
 @Injectable()
@@ -38,6 +43,11 @@ export class MemberRepository implements IMemberRepository {
         registeredAt: true,
         address: true,
         generation: true,
+        memberAccount: {
+          select: {
+            nickname: true,
+          },
+        },
         major: {
           select: {
             id: true,

--- a/src/member/member/type/create-member-data.type.ts
+++ b/src/member/member/type/create-member-data.type.ts
@@ -1,10 +1,7 @@
-type CreateMemberData = {
+export type CreateMemberData = {
   name: string;
   studentId: string;
   generation: number;
   majorId: number;
   registeredAt: Date;
-  email: string | null;
-  phone: string | null;
-  address: string | null;
 };

--- a/src/member/member/type/major-data.type.ts
+++ b/src/member/member/type/major-data.type.ts
@@ -1,0 +1,5 @@
+export type MajorData = {
+  id: number;
+  name: string;
+  college: string;
+};

--- a/src/member/member/type/major-input.type.ts
+++ b/src/member/member/type/major-input.type.ts
@@ -1,0 +1,5 @@
+export type MajorInput = {
+  id: number;
+  name: string;
+  college: string;
+};

--- a/src/member/member/type/member-data-with-major.type.ts
+++ b/src/member/member/type/member-data-with-major.type.ts
@@ -11,5 +11,8 @@ export type MemberDataWithMajor = {
   email: string | null;
   phone: string | null;
   address: string | null;
+  memberAccount: {
+    nickname: string;
+  } | null;
   major: MajorData;
 };

--- a/src/member/member/type/member-data-with-major.type.ts
+++ b/src/member/member/type/member-data-with-major.type.ts
@@ -1,0 +1,15 @@
+import { MemberType } from '@prisma/client';
+import { MajorData } from './major-data.type';
+
+export type MemberDataWithMajor = {
+  id: string;
+  name: string;
+  type: MemberType;
+  studentId: string;
+  generation: number;
+  registeredAt: Date;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+  major: MajorData;
+};

--- a/src/member/member/type/member-data.type.ts
+++ b/src/member/member/type/member-data.type.ts
@@ -11,4 +11,7 @@ export type MemberData = {
   phone: string | null;
   address: string | null;
   majorId: number;
+  memberAccount: {
+    nickname: string;
+  } | null;
 };

--- a/src/member/member/type/member-data.type.ts
+++ b/src/member/member/type/member-data.type.ts
@@ -1,0 +1,14 @@
+import { MemberType } from '@prisma/client';
+
+export type MemberData = {
+  id: string;
+  name: string;
+  type: MemberType;
+  studentId: string;
+  generation: number;
+  registeredAt: Date;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+  majorId: number;
+};

--- a/src/member/member/type/member-input.type.ts
+++ b/src/member/member/type/member-input.type.ts
@@ -1,14 +1,16 @@
 import { MemberType } from '@prisma/client';
+import { MajorInput } from './major-input.type';
 
-export type MemberDomainData = {
+export type MemberInput = {
   id: string;
   name: string;
   type: MemberType;
   studentId: string;
   generation: number;
-  majorId: number;
   registeredAt: Date;
   email: string | null;
   phone: string | null;
   address: string | null;
+  // major에 id를 담으면 lazy loading, major에 MajorData를 담으면 eager loading
+  major: { id: number } | MajorInput;
 };

--- a/src/member/member/type/member-input.type.ts
+++ b/src/member/member/type/member-input.type.ts
@@ -11,6 +11,7 @@ export type MemberInput = {
   email: string | null;
   phone: string | null;
   address: string | null;
+  nickname: string | null;
   // major에 id를 담으면 lazy loading, major에 MajorData를 담으면 eager loading
   major: { id: number } | MajorInput;
 };

--- a/src/member/member/type/update-member-data.type.ts
+++ b/src/member/member/type/update-member-data.type.ts
@@ -1,0 +1,14 @@
+import { MemberType } from '@prisma/client';
+
+export type UpdateMemberData = {
+  name?: string;
+  type?: MemberType;
+  studentId?: string;
+  generation?: number;
+  registeredAt?: Date;
+  email?: string | null;
+  phone?: string | null;
+  address?: string | null;
+  majorId?: number;
+  nickname?: string;
+};


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [X] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc


## Purpose
- admin 권한과 일반 member 권한에서 다룰 수 있는 api 엔드포인트가 다르므로 controller를 분리했습니다.
- 기존 admin 수정 엔드포인트에 특정 회원의 권한을 변경할 수 있는 필드를 추가했습니다.
- 일반 member의 권한에서 자기 자신의 정보를 조회, 수정할 수 있는 엔드포인트를 추가하였습니다.
- admin이 명부를 생성하고 수정할때, 입력할 수 있는 정보를 줄였습니다.


## Why
- 인증, 인가가 가능해짐에 따라, member 모듈에서 부족했던 엔드포인트들을 보완하는 PR입니다.
- 기존 admin 엔드포인트에서 email, phone, address같은 nullable field까지 받고 있었는데, 이는 이후에 개인이 수정할 수 있는 정보이므로 제외하는 방향으로 수정했습니다.

## Related issue
- resolve #10 
